### PR TITLE
Fix scaling to look accurate for resolutions other than 1920x1080.

### DIFF
--- a/MenuAPI/MenuController.cs
+++ b/MenuAPI/MenuController.cs
@@ -14,8 +14,9 @@ namespace MenuAPI
         public const string _texture_dict = "commonmenu";
         public const string _header_texture = "interaction_bgd";
 
-        public static float ScreenWidth { get { int width = 0, height = 0; GetScreenActiveResolution(ref width, ref height); return (float)width; } }
-        public static float ScreenHeight { get { int width = 0, height = 0; GetScreenActiveResolution(ref width, ref height); return (float)height; } }
+        private static float AspectRatio => GetScreenAspectRatio(false);
+        public static float ScreenWidth => 1080 * AspectRatio;
+        public static float ScreenHeight => 1080;
         public static bool DisableMenuButtons { get; set; } = false;
         public static bool AreMenuButtonsEnabled => Menus.Any((m) => m.Visible) && !Game.IsPaused && CitizenFX.Core.UI.Screen.Fading.IsFadedIn && !IsPlayerSwitchInProgress() && !DisableMenuButtons && !Game.Player.IsDead;
 


### PR DESCRIPTION
Currently, MenuAPI uses absolute screen pixels for all measurements. This looks out of place on resolutions other than 1920x1080, and on HiDPI monitors, will result in menus that look unreadable.

This PR takes into account that all reference measurements were made at 1920x1080, and assumes most measurements will be accurate in height primarily.

This change has been verified to look accurate - not stretch, not be misaligned compared to the GTA HUD, and scale correctly - on a number of resolutions and aspect ratios, from 800x600 to 2560x1440, and from 2560x600 to 800x1440, which are the maximum and minimum resolutions supported by both the testing machine's monitor and GTA.