### PR TITLE
Avoid disabling MenuToggleKey

### DIFF
--- a/MenuAPI/MenuController.cs
+++ b/MenuAPI/MenuController.cs
@@ -458,11 +458,11 @@ namespace MenuAPI
         {
 
 #if FIVEM
-            Game.DisableControlThisFrame(0, MenuToggleKey);
             if (!Game.IsPaused && !IsPauseMenuRestarting() && IsScreenFadedIn() && !IsPlayerSwitchInProgress() && !Game.Player.IsDead && !DisableMenuButtons)
             {
                 if (IsAnyMenuOpen())
                 {
+                    Game.DisableControlThisFrame(0, MenuToggleKey);
                     if (Game.CurrentInputMode == InputMode.MouseAndKeyboard)
                     {
                         if ((Game.IsControlJustPressed(0, MenuToggleKey) || Game.IsDisabledControlJustPressed(0, MenuToggleKey)) && !PreventExitingMenu)


### PR DESCRIPTION
It should be avoided to flag the control for MenuToggleKey as disabled if there is no menu open.

Some scripts might want to perform specific actions based on control check state and do different based on if the control is enabled or disabled (or they can just don't care about the status but it's up to them). Having the MenuToggleKey flagged as disabled seems logically wrong as would never allow to such control to be enabled. 

MenuAPI shouldn't flag any control as disabled for the entire lifetime of the script, it should only do it for the limited time required to perform its own checks.