### PR TITLE
Tweak navigation with left/right arrows

### DIFF
--- a/MenuAPI/Menu.cs
+++ b/MenuAPI/Menu.cs
@@ -998,10 +998,11 @@ namespace MenuAPI
                     SelectItem(checkbox);
                 }
 #endif
-                // If the item is enabled and it's not any of the above, just select it.
-                else if (item.Enabled)
+                // If the item is not any of the above, return to parent menu.
+                else if (MenuController.NavigateMenuUsingArrows)
                 {
-                    SelectItem(item);
+                    if (!MenuController.DisableBackButton && !(MenuController.PreventExitingMenu && ParentMenu == null))
+                        GoBack();
                 }
             }
         }
@@ -1074,9 +1075,10 @@ namespace MenuAPI
                 }
 #endif
                 // If the item is enabled and it's not any of the above, just select it.
-                else if (item.Enabled)
+                else if (MenuController.NavigateMenuUsingArrows)
                 {
-                    SelectItem(item);
+                    if(item.Enabled)
+                        SelectItem(item);
                 }
             }
         }

--- a/MenuAPI/MenuController.cs
+++ b/MenuAPI/MenuController.cs
@@ -63,6 +63,7 @@ namespace MenuAPI
             !Call<bool>(IS_ENTITY_DEAD, PlayerPedId());
 #endif
 
+        public static bool NavigateMenuUsingArrows { get; set; } = true;
         public static bool EnableManualGCs { get; set; } = true;
         public static bool DontOpenAnyMenu { get; set; } = false;
         public static bool PreventExitingMenu { get; set; } = false;


### PR DESCRIPTION
* Generic MenuItem will go back to parent when GoLeft is invoked as duality with GoRight which navigates to child menu

* Added NavigateMenuUsingArrows property to MenuController to enable/disable navigation using left/right arrows (enabled by default for backwards compatibility)