### PR TITLE
Fix instructional buttons not scaling to >16:9 resolutions

### DIFF
--- a/MenuAPI/MenuController.cs
+++ b/MenuAPI/MenuController.cs
@@ -1112,6 +1112,8 @@ namespace MenuAPI
                 await Delay(0);
             }
 
+            DrawScaleformMovieFullscreen(_scale, 255, 255, 255, 0, 0);
+
             BeginScaleformMovieMethod(_scale, "CLEAR_ALL");
             EndScaleformMovieMethod();
 


### PR DESCRIPTION
Same change as TomGrobbe/vMenu#259.