### PR TITLE
Add support for multiple menu toggle keys

### DIFF
--- a/MenuAPI/Menu.cs
+++ b/MenuAPI/Menu.cs
@@ -592,6 +592,8 @@ namespace MenuAPI
         }
         public List<ButtonPressHandler> ButtonPressHandlers = new List<ButtonPressHandler>();
 
+        public Control MenuToggleKey;
+
         #endregion
 
         #region Constructors

--- a/MenuAPI/MenuController.cs
+++ b/MenuAPI/MenuController.cs
@@ -67,13 +67,6 @@ namespace MenuAPI
         public static bool PreventExitingMenu { get; set; } = false;
         public static bool DisableBackButton { get; set; } = false;
         public static bool SetDrawOrder { get; set; } = true;
-        public static Control MenuToggleKey { get; set; }
-#if FIVEM
-            = Control.InteractionMenu;
-#endif
-#if REDM
-            = Control.PlayerMenu;
-#endif
 
         public static bool EnableMenuToggleKeyOnController { get; set; } = true;
 
@@ -233,6 +226,11 @@ namespace MenuAPI
                 return VisibleMenus.FirstOrDefault();
             }
             return null;
+        }
+
+        public static HashSet<Menu> GetCurrentOpenMenus()
+        {
+            return VisibleMenus;
         }
 
         /// <summary>
@@ -705,7 +703,6 @@ namespace MenuAPI
         private void HandleMenuToggleKeyForKeyboard()
         {
             if (
-                (Game.IsControlJustPressed(0, MenuToggleKey) || Game.IsDisabledControlJustPressed(0, MenuToggleKey)) &&
                 !Game.IsPaused &&
                 !Game.Player.IsDead &&
                 !IsPlayerSwitchInProgress() &&
@@ -717,13 +714,8 @@ namespace MenuAPI
                 {
                     return;
                 }
-                if (MainMenu != null)
-                {
-                    MainMenu.OpenMenu();
-                }
-                else
-                {
-                    Menus.First().OpenMenu();
+                foreach (Menu menu in Menus.Where(menu => !menu.Visible && (Game.IsControlJustPressed(0, menu.MenuToggleKey) || Game.IsDisabledControlJustPressed(0, menu.MenuToggleKey)))) {
+                    menu.OpenMenu();
                 }
             }
         }
@@ -754,15 +746,18 @@ namespace MenuAPI
 
         private void DisableMenuKeyThisFrame()
         {
-            Game.DisableControlThisFrame(0, MenuToggleKey);
             if (Game.CurrentInputMode == InputMode.MouseAndKeyboard)
             {
-                if ((Game.IsControlJustPressed(0, MenuToggleKey) || Game.IsDisabledControlJustPressed(0, MenuToggleKey)) && !PreventExitingMenu)
+                var menus = new HashSet<Menu>(GetCurrentOpenMenus());
+                foreach (Menu menu in menus)
                 {
-                    var menu = GetCurrentMenu();
-                    if (menu != null)
+                    Game.DisableControlThisFrame(0, menu.MenuToggleKey);
+                    if ((Game.IsControlJustPressed(0, menu.MenuToggleKey) || Game.IsDisabledControlJustPressed(0, menu.MenuToggleKey)) && !PreventExitingMenu)
                     {
-                        menu.CloseMenu();
+                        if (menu != null)
+                        {
+                            menu.CloseMenu();
+                        }
                     }
                 }
             }

--- a/MenuAPI/MenuController.cs
+++ b/MenuAPI/MenuController.cs
@@ -710,10 +710,6 @@ namespace MenuAPI
                 IsScreenFadedIn()
             )
             {
-                if (!Menus.Any())
-                {
-                    return;
-                }
                 foreach (Menu menu in Menus.Where(menu => !menu.Visible && (Game.IsControlJustPressed(0, menu.MenuToggleKey) || Game.IsDisabledControlJustPressed(0, menu.MenuToggleKey)))) {
                     menu.OpenMenu();
                 }
@@ -754,10 +750,7 @@ namespace MenuAPI
                     Game.DisableControlThisFrame(0, menu.MenuToggleKey);
                     if ((Game.IsControlJustPressed(0, menu.MenuToggleKey) || Game.IsDisabledControlJustPressed(0, menu.MenuToggleKey)) && !PreventExitingMenu)
                     {
-                        if (menu != null)
-                        {
-                            menu.CloseMenu();
-                        }
+                        menu?.CloseMenu();
                     }
                 }
             }


### PR DESCRIPTION
I added the `MenuToggleKey` property to the Menu class. The script no longer checks if the one main menu opening key is pressed, but iterates through all registered menus and checks if their key is pressed to show and hide them. This adds the feature that you can use this api more than once without the need to add your own key press listener and without having the issue that wrong menus are being opened.

**Warning to the vMenu author**
You would have to set the Menu's toggle key, and remove the assignment of the static `MenuController.MenuToggleKey`.