### PR TITLE
Minor optimizations and fix lines being cut when newlines are in the string

### DIFF
--- a/MenuAPI/MenuController.cs
+++ b/MenuAPI/MenuController.cs
@@ -239,7 +239,7 @@ namespace MenuAPI
         /// Returns true if any menu is currently open.
         /// </summary>
         /// <returns></returns>
-        public static bool IsAnyMenuOpen() => VisibleMenus.Any();
+        public static bool IsAnyMenuOpen() => VisibleMenus.Count > 0;
 
 
         #region Process Menu Buttons
@@ -446,12 +446,15 @@ namespace MenuAPI
 #endif
 #if REDM
             ProcessToggleMenuButtonRedM();
-            await Task.FromResult(0);
 #endif
         }
 #if REDM
         private void ProcessToggleMenuButtonRedM()
         {
+            if (MenuToggleKey == 0)
+            {
+                return;
+            }
             DisableControlAction(0, (uint)MenuToggleKey, true);
             if (
                 !IsPauseMenuActive() &&

--- a/MenuAPI/items/MenuItem.cs
+++ b/MenuAPI/items/MenuItem.cs
@@ -4,6 +4,7 @@ using CitizenFX.Core;
 using static CitizenFX.Core.Native.API;
 using static CitizenFX.Core.Native.Function;
 using static CitizenFX.Core.Native.Hash;
+using System.Text.RegularExpressions;
 
 namespace MenuAPI
 {
@@ -226,23 +227,9 @@ namespace MenuAPI
                 {
                     string text = value;
                     int maxLength = 50;
-                    List<string> lines = new List<string>();
-                    while (text.Length > maxLength)
+                    if (text.Length > maxLength)
                     {
-                        var substr = text.Substring(0, Math.Min(text.Length - 1, maxLength));
-                        var lastIndex = substr.LastIndexOf(" ");
-                        if (lastIndex == -1)
-                        {
-                            lastIndex = Math.Min(text.Length - 1, maxLength);
-                        }
-                        lines.Add(text.Substring(0, lastIndex));
-                        text = text.Substring(lastIndex);
-                    }
-                    lines.Add(text);
-                    text = "";
-                    foreach (var str in lines)
-                    {
-                        text += str + "\n";
+                        text = Regex.Replace(text, @"(.{1," + maxLength + @"})(?:\s|$)", "$1\n");
                     }
                     _description = text;
                 }


### PR DESCRIPTION
Listening to the Menu Keys seems unecessary when the key is 0, and this thread uses quite a bit of resources with the native calls, so simply returning when the key is zero seems like a good options here.

The other commit changes the line split to a regex, this might be more performant (haven't tested that), but the main point with this is that if new lines are in the string it would still cut off the string, that seems unecessary, this fixes that by also seeing new lines as whitespace characters and replacing the new line with a new line giving you more control over where the new lines are.